### PR TITLE
Default to using copies of state, instead of patches

### DIFF
--- a/.size-limit.ts
+++ b/.size-limit.ts
@@ -20,8 +20,8 @@ export default [
   },
   {
     path: "dist/index.js",
-    import: "{ createNoPatchHistoryAdapter }",
-    name: "import { createNoPatchHistoryAdapter } from 'history-adapter'",
+    import: "{ createPatchHistoryAdapter }",
+    name: "import { createPatchHistoryAdapter } from 'history-adapter'",
   },
   {
     path: "dist/redux.js",
@@ -30,7 +30,7 @@ export default [
   },
   {
     path: "dist/redux.js",
-    import: "{ createNoPatchHistoryAdapter }",
-    name: "import { createNoPatchHistoryAdapter } from 'history-adapter/redux'",
+    import: "{ createPatchHistoryAdapter }",
+    name: "import { createPatchHistoryAdapter } from 'history-adapter/redux'",
   },
 ] satisfies SizeLimitConfig;

--- a/.size-limit.ts
+++ b/.size-limit.ts
@@ -21,11 +21,16 @@ export default [
   {
     path: "dist/index.js",
     import: "{ createNoPatchHistoryAdapter }",
-    name: "import { createNoPatchHistoryAdapter } from 'history-adapter' (CJS)",
+    name: "import { createNoPatchHistoryAdapter } from 'history-adapter'",
   },
   {
     path: "dist/redux.js",
     import: "{ createHistoryAdapter }",
     name: "import { createHistoryAdapter } from 'history-adapter/redux'",
+  },
+  {
+    path: "dist/redux.js",
+    import: "{ createNoPatchHistoryAdapter }",
+    name: "import { createNoPatchHistoryAdapter } from 'history-adapter/redux'",
   },
 ] satisfies SizeLimitConfig;

--- a/.size-limit.ts
+++ b/.size-limit.ts
@@ -24,6 +24,11 @@ export default [
     name: "import { createPatchHistoryAdapter } from 'history-adapter'",
   },
   {
+    path: "dist/index.js",
+    import: "{ buildCreateHistoryAdapter }",
+    name: "import { buildCreateHistoryAdapter } from 'history-adapter'",
+  },
+  {
     path: "dist/redux.js",
     import: "{ createHistoryAdapter }",
     name: "import { createHistoryAdapter } from 'history-adapter/redux'",

--- a/.size-limit.ts
+++ b/.size-limit.ts
@@ -19,6 +19,11 @@ export default [
     name: "import { createHistoryAdapter } from 'history-adapter'",
   },
   {
+    path: "dist/index.js",
+    import: "{ createNoPatchHistoryAdapter }",
+    name: "import { createNoPatchHistoryAdapter } from 'history-adapter' (CJS)",
+  },
+  {
     path: "dist/redux.js",
     import: "{ createHistoryAdapter }",
     name: "import { createHistoryAdapter } from 'history-adapter/redux'",

--- a/package.json
+++ b/package.json
@@ -92,8 +92,7 @@
       "esm",
       "cjs"
     ],
-    "dts": true,
-    "minify": true
+    "dts": true
   },
   "dependencies": {
     "immer": "^10.0.3"

--- a/src/creator.test.ts
+++ b/src/creator.test.ts
@@ -6,7 +6,7 @@ import {
 import { describe, expect, it } from "vitest";
 import { historyMethodsCreator, undoableCreatorsCreator } from "./creator";
 import type { HistoryState } from "./redux";
-import { createHistoryAdapter, createNoPatchHistoryAdapter } from "./redux";
+import { createHistoryAdapter, createPatchHistoryAdapter } from "./redux";
 
 interface Book {
   title: string;
@@ -95,9 +95,9 @@ describe("Slice creators", () => {
 
     store.dispatch(undone());
 
-    expect(selectLastBook(store.getState())).toBe(book2);
+    expect(selectLastBook(store.getState())).toBe(book1);
 
-    store.dispatch(jumped(-1));
+    store.dispatch(jumped(1));
 
     expect(selectLastBook(store.getState())).toStrictEqual(book2);
 
@@ -204,9 +204,9 @@ describe("Slice creators", () => {
 
     store.dispatch(undone());
 
-    expect(selectLastBook(store.getState())).toBe(book2);
+    expect(selectLastBook(store.getState())).toBe(book1);
 
-    store.dispatch(jumped(-1));
+    store.dispatch(jumped(1));
 
     expect(selectLastBook(store.getState())).toStrictEqual(book2);
 
@@ -283,8 +283,8 @@ describe("Slice creators", () => {
 
     expect(selectLastBook(store.getState())).toBeUndefined();
   });
-  it("works without patches", () => {
-    const bookAdapter = createNoPatchHistoryAdapter<Array<Book>>();
+  it("works with patches", () => {
+    const bookAdapter = createPatchHistoryAdapter<Array<Book>>();
     const bookSlice = createAppSlice({
       name: "book",
       initialState: bookAdapter.getInitialState([]),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -64,7 +64,7 @@ describe("createHistoryAdapter", () => {
         (books, book: Book, undoable?: boolean) => {
           books.push(book);
         },
-        (book, undoable) => undoable,
+        { isUndoable: (book, undoable) => undoable },
       );
       const initialState = booksHistoryAdapter.getInitialState([]);
       const nextState = addBook(initialState, book1, false);
@@ -383,7 +383,7 @@ describe("createPatchHistoryAdapter", () => {
         (books, book: Book, undoable?: boolean) => {
           books.push(book);
         },
-        (book, undoable) => undoable,
+        { isUndoable: (book, undoable) => undoable },
       );
       const initialState = booksHistoryAdapter.getInitialState([]);
       const nextState = addBook(initialState, book1, false);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import type { HistoryState } from ".";
-import { createHistoryAdapter } from ".";
+import type { HistoryState, NonPatchHistoryState } from ".";
+import { createHistoryAdapter, createNoPatchHistoryAdapter } from ".";
 import { nothing, produce } from "immer";
 
 interface Book {
@@ -307,6 +307,317 @@ describe("createHistoryAdapter", () => {
   describe("config", () => {
     it("can limit history size", () => {
       const historyAdapter = createHistoryAdapter<{ value: number }>({
+        limit: 2,
+      });
+      const initialState = historyAdapter.getInitialState({ value: 0 });
+      const increment = historyAdapter.undoable((state) => {
+        state.value++;
+      });
+
+      let currentState = initialState;
+      for (let i = 0; i < 5; i++) {
+        currentState = increment(currentState);
+      }
+
+      expect(currentState.present).toEqual({ value: 5 });
+      expect(currentState.past.length).toBe(2);
+
+      currentState = historyAdapter.jump(currentState, -5);
+
+      expect(currentState.present).toEqual({ value: 3 });
+    });
+  });
+});
+
+describe("createNoPatchHistoryAdapter", () => {
+  const booksHistoryAdapter = createNoPatchHistoryAdapter<Array<Book>>();
+
+  describe("getInitialState", () => {
+    it("returns an initial state", () => {
+      expect(booksHistoryAdapter.getInitialState([])).toEqual<
+        NonPatchHistoryState<Array<Book>>
+      >({
+        past: [],
+        present: [],
+        future: [],
+        paused: false,
+      });
+    });
+  });
+
+  describe("undoable", () => {
+    it("wraps a function to automatically update patches", () => {
+      const addBook = booksHistoryAdapter.undoable((books, book: Book) => {
+        books.push(book);
+      });
+      const initialState = booksHistoryAdapter.getInitialState([]);
+      const nextState = addBook(initialState, book1);
+      expect(nextState).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [[]],
+        present: [book1],
+        future: [],
+        paused: false,
+      });
+    });
+    it("handles nothing value to return undefined", () => {
+      const optionalHistoryAdapter = createNoPatchHistoryAdapter<
+        string | undefined
+      >();
+      const clearValue = optionalHistoryAdapter.undoable(() => nothing);
+      expect(clearValue(optionalHistoryAdapter.getInitialState("foo"))).toEqual<
+        NonPatchHistoryState<string | undefined>
+      >({
+        past: ["foo"],
+        present: undefined,
+        future: [],
+        paused: false,
+      });
+    });
+    it("allows deriving from arguments whether update should be undoable", () => {
+      const addBook = booksHistoryAdapter.undoable(
+        (books, book: Book, undoable?: boolean) => {
+          books.push(book);
+        },
+        (book, undoable) => undoable,
+      );
+      const initialState = booksHistoryAdapter.getInitialState([]);
+      const nextState = addBook(initialState, book1, false);
+      expect(nextState).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [book1],
+        future: [],
+        paused: false,
+      });
+    });
+    it("can be used as a mutator if already working with drafts", () => {
+      const addBook = booksHistoryAdapter.undoable((books, book: Book) => {
+        books.push(book);
+      });
+      const initialState = booksHistoryAdapter.getInitialState([]);
+      const nextState = produce(initialState, (draft) => {
+        addBook(draft, book1);
+      });
+      expect(nextState).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [[]],
+        present: [book1],
+        future: [],
+        paused: false,
+      });
+    });
+    it("can be provided with a selector if working with nested state", () => {
+      const addBook = booksHistoryAdapter.undoable(
+        (books, book: Book) => {
+          books.push(book);
+        },
+        {
+          selectHistoryState: (state: {
+            books: NonPatchHistoryState<Array<Book>>;
+          }) => state.books,
+        },
+      );
+      const initialState = { books: booksHistoryAdapter.getInitialState([]) };
+
+      const nextState = addBook(initialState, book1);
+
+      expect(nextState).toEqual({
+        books: {
+          past: [[]],
+          present: [book1],
+          future: [],
+          paused: false,
+        },
+      });
+    });
+  });
+  describe("undo", () => {
+    const initialState = booksHistoryAdapter.getInitialState([]);
+    const addBook = booksHistoryAdapter.undoable((books, book: Book) => {
+      books.push(book);
+    });
+    const updatedState = addBook(initialState, book1);
+    it("applies previous patch if available", () => {
+      expect(booksHistoryAdapter.undo(updatedState)).toEqual<
+        NonPatchHistoryState<Array<Book>>
+      >({
+        past: [],
+        present: [],
+        future: [[book1]],
+        paused: false,
+      });
+    });
+    it("can be used as a mutator if already working with drafts", () => {
+      expect(
+        produce(updatedState, (draft) => {
+          booksHistoryAdapter.undo(draft);
+        }),
+      ).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [],
+        future: [[book1]],
+        paused: false,
+      });
+    });
+  });
+
+  describe("redo", () => {
+    const initialState = booksHistoryAdapter.getInitialState([]);
+    const addBook = booksHistoryAdapter.undoable((books, book: Book) => {
+      books.push(book);
+    });
+    const updatedState = addBook(initialState, book1);
+    const undoneState = booksHistoryAdapter.undo(updatedState);
+
+    it("applies next patch if available", () => {
+      expect(booksHistoryAdapter.redo(undoneState)).toEqual<
+        NonPatchHistoryState<Array<Book>>
+      >({
+        past: [[]],
+        present: [book1],
+        future: [],
+        paused: false,
+      });
+    });
+    it("can be used as a mutator if already working with drafts", () => {
+      expect(
+        produce(undoneState, (draft) => {
+          booksHistoryAdapter.redo(draft);
+        }),
+      ).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [[]],
+        present: [book1],
+        future: [],
+        paused: false,
+      });
+    });
+  });
+
+  describe("jump", () => {
+    const initialState = booksHistoryAdapter.getInitialState([]);
+    const addBook = booksHistoryAdapter.undoable((books, book: Book) => {
+      books.push(book);
+    });
+    const updatedState = addBook(initialState, book1);
+    const secondState = addBook(updatedState, book2);
+
+    it("moves the state back or forward in history by n steps", () => {
+      const jumpedState = booksHistoryAdapter.jump(secondState, -2);
+      expect(jumpedState).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [],
+        future: [[book1], [book1, book2]],
+        paused: false,
+      });
+      const jumpedForwardState = booksHistoryAdapter.jump(jumpedState, 2);
+      expect(jumpedForwardState).toEqual(secondState);
+    });
+    it("can be used as a mutator if already working with drafts", () => {
+      expect(
+        produce(secondState, (draft) => {
+          booksHistoryAdapter.jump(draft, -2);
+        }),
+      ).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [],
+        future: [[book1], [book1, book2]],
+        paused: false,
+      });
+    });
+  });
+
+  describe("pause", () => {
+    it("can be used to pause history tracking", () => {
+      const initialState = booksHistoryAdapter.getInitialState([]);
+      const pausedState = booksHistoryAdapter.pause(initialState);
+      expect(pausedState).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [],
+        future: [],
+        paused: true,
+      });
+    });
+    it("can be used as a mutator if already working with drafts", () => {
+      const initialState = booksHistoryAdapter.getInitialState([]);
+      expect(
+        produce(initialState, (draft) => {
+          booksHistoryAdapter.pause(draft);
+        }),
+      ).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [],
+        future: [],
+        paused: true,
+      });
+    });
+    it("is respected by undoable functions", () => {
+      const addBook = booksHistoryAdapter.undoable((books, book: Book) => {
+        books.push(book);
+      });
+      const initialState = booksHistoryAdapter.getInitialState([]);
+      const pausedState = booksHistoryAdapter.pause(initialState);
+      const nextState = addBook(pausedState, book1);
+      expect(nextState).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [book1],
+        future: [],
+        paused: true,
+      });
+    });
+  });
+
+  describe("resume", () => {
+    it("can be used to resume history tracking", () => {
+      const initialState = booksHistoryAdapter.getInitialState([]);
+      const pausedState = booksHistoryAdapter.pause(initialState);
+      const resumedState = booksHistoryAdapter.resume(pausedState);
+      expect(resumedState).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [],
+        future: [],
+        paused: false,
+      });
+    });
+    it("can be used as a mutator if already working with drafts", () => {
+      const initialState = booksHistoryAdapter.getInitialState([]);
+      const pausedState = booksHistoryAdapter.pause(initialState);
+      expect(
+        produce(pausedState, (draft) => {
+          booksHistoryAdapter.resume(draft);
+        }),
+      ).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [],
+        future: [],
+        paused: false,
+      });
+    });
+    it("is respected by undoable functions", () => {
+      const addBook = booksHistoryAdapter.undoable((books, book: Book) => {
+        books.push(book);
+      });
+      const initialState = booksHistoryAdapter.getInitialState([]);
+      const pausedState = booksHistoryAdapter.pause(initialState);
+      const withBook = addBook(pausedState, book1);
+      expect(withBook).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [],
+        present: [book1],
+        future: [],
+        paused: true,
+      });
+
+      const resumedState = booksHistoryAdapter.resume(withBook);
+      const nextState = addBook(resumedState, book2);
+      expect(nextState).toEqual<NonPatchHistoryState<Array<Book>>>({
+        past: [[book1]],
+        present: [book1, book2],
+        future: [],
+        paused: false,
+      });
+    });
+  });
+
+  describe("config", () => {
+    it("can limit history size", () => {
+      const historyAdapter = createNoPatchHistoryAdapter<{ value: number }>({
         limit: 2,
       });
       const initialState = historyAdapter.getInitialState({ value: 0 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,16 +208,6 @@ type BuildHistoryAdapterConfig<StateFn extends HistoryStateFn> = {
       ) => ApplyDataType<Data, StateFn>;
     });
 
-export interface CreateHistoryAdapter<StateFn extends HistoryStateFn> {
-  <Data>(
-    adapterConfig?: HistoryAdapterConfig,
-  ): HistoryAdapter<Data, ApplyDataType<Data, StateFn>>;
-  /** not real keys, included for inference */
-  __Types: {
-    stateFn: StateFn;
-  };
-}
-
 function buildCreateHistoryAdapter<StateType extends HistoryStateFn>({
   undoMutably,
   redoMutably,
@@ -225,7 +215,7 @@ function buildCreateHistoryAdapter<StateType extends HistoryStateFn>({
   onCreate,
   getInitialState: getInitialStateCustom = getInitialState,
 }: BuildHistoryAdapterConfig<StateType>) {
-  function createHistoryAdapter<Data>(
+  return function createHistoryAdapter<Data>(
     adapterConfig: HistoryAdapterConfig = {},
   ): HistoryAdapter<Data, ApplyDataType<Data, StateType>> {
     type State = ApplyDataType<Data, StateType>;
@@ -280,8 +270,7 @@ function buildCreateHistoryAdapter<StateType extends HistoryStateFn>({
         });
       },
     };
-  }
-  return createHistoryAdapter as CreateHistoryAdapter<StateType>;
+  };
 }
 
 export const createHistoryAdapter =

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ type HistoryEntryType<State> = State extends BaseHistoryState<any, infer T>
   ? T
   : never;
 
-export interface HistoryAdapterConfig {
+export interface BaseHistoryAdapterConfig {
   /**
    * Maximum number of past states to keep.
    * If limit is reached, the oldest state will be removed.
@@ -39,7 +39,7 @@ export interface HistoryAdapterConfig {
 export interface BaseHistoryStateFn {
   state: BaseHistoryState<this["data"], unknown>;
   data: unknown;
-  config: HistoryAdapterConfig;
+  config: BaseHistoryAdapterConfig;
 }
 
 type GetStateType<Data, StateFn extends BaseHistoryStateFn> = (StateFn & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,7 +302,7 @@ export const createHistoryAdapter =
         config: WrapRecipeConfig<Args>,
         adapterConfig: HistoryAdapterConfig,
       ) =>
-      (state, ...args: Args) => {
+      (state: Draft<HistoryState<Data>>, ...args: Args) => {
         const [{ present }, redo, undo] = produceWithPatches(state, (draft) => {
           const result = recipe(draft.present as Draft<Data>, ...args);
           if (result === nothing) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,8 @@ type GetInitialState<StateFn extends BaseHistoryStateFn> = <Data>(
   initialData: Data,
 ) => GetStateType<Data, StateFn>;
 
+type ApplyOp = "undo" | "redo";
+
 export type BuildHistoryAdapterConfig<StateFn extends BaseHistoryStateFn> = {
   /**
    * Function to apply a history entry to the state.
@@ -156,7 +158,7 @@ export type BuildHistoryAdapterConfig<StateFn extends BaseHistoryStateFn> = {
   applyEntry: (
     state: StateFn["state"],
     historyEntry: HistoryEntryType<StateFn["state"]>,
-    op: "undo" | "redo",
+    op: ApplyOp,
   ) => HistoryEntryType<StateFn["state"]>;
   /**
    * Function to wrap a recipe to automatically update patch history according to changes.
@@ -304,10 +306,7 @@ export const createHistoryAdapter = buildCreateHistoryAdapter<HistoryStateFn>({
     },
 });
 
-export interface PatchState {
-  undo: Array<Patch>;
-  redo: Array<Patch>;
-}
+export type PatchState = Record<ApplyOp, Array<Patch>>;
 
 export type PatchHistoryState<Data> = BaseHistoryState<Data, PatchState>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,21 +166,40 @@ type ApplyEntry<StateFn extends BaseHistoryStateFn> = (
 ) => HistoryEntryType<StateFn["state"]>;
 
 type BuildHistoryAdapterConfig<StateFn extends BaseHistoryStateFn> = {
+  /**
+   * Function to apply a history entry to the state.
+   * Should return a history entry to be added to the opposite stack (i.e. past or future).
+   */
   applyEntry:
     | ApplyEntry<StateFn>
     | Record<"undo" | "redo", ApplyEntry<StateFn>>;
+  /**
+   * Function to wrap a recipe to automatically update patch history according to changes.
+   * Should return a function that receives the state and arguments, and returns a history entry to be added to the past stack.
+   */
   wrapRecipe: <Data, Args extends Array<any>>(
     recipe: (draft: Draft<Data>, ...args: Args) => ValidRecipeReturnType<Data>,
   ) => (
     state: Draft<GetStateType<Data, StateFn>>,
     ...args: Args
   ) => HistoryEntryType<GetStateType<Data, StateFn>>;
+  /**
+   * A function to run when the adapter is created.
+   *
+   * Useful for setup such as enabling patches.
+   */
   onCreate?: (config?: GetConfigType<unknown, StateFn>) => void;
 } & (BaseHistoryState<any, any> extends GetStateType<unknown, StateFn>
   ? {
+      /**
+       * Function to construct an initial state with no history.
+       */
       getInitialState?: GetInitialState<StateFn>;
     }
   : {
+      /**
+       * Function to construct an initial state with no history.
+       */
       getInitialState: GetInitialState<StateFn>;
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
 } from "immer";
 import type { NoInfer } from "./utils";
 
-type MaybeDraft<T> = T | Draft<T>;
+export type MaybeDraft<T> = T | Draft<T>;
 
 type ValidRecipeReturnType<State> =
   | State
@@ -42,7 +42,7 @@ export type MaybeDraftNonPatchHistoryState<Data> =
   | NonPatchHistoryState<Data>
   | Draft<NonPatchHistoryState<Data>>;
 
-interface HistoryStateFn {
+export interface HistoryStateFn {
   state: BaseHistoryState<this["data"], unknown>;
   data: unknown;
 }
@@ -55,7 +55,7 @@ interface NonPatchHistoryStateFn extends HistoryStateFn {
   state: NonPatchHistoryState<this["data"]>;
 }
 
-type ApplyDataType<Data, StateFn extends HistoryStateFn> = (StateFn & {
+export type ApplyDataType<Data, StateFn extends HistoryStateFn> = (StateFn & {
   data: Data;
 })["state"];
 
@@ -208,6 +208,16 @@ type BuildHistoryAdapterConfig<StateFn extends HistoryStateFn> = {
       ) => ApplyDataType<Data, StateFn>;
     });
 
+export interface CreateHistoryAdapter<StateFn extends HistoryStateFn> {
+  <Data>(
+    adapterConfig?: HistoryAdapterConfig,
+  ): HistoryAdapter<Data, ApplyDataType<Data, StateFn>>;
+  /** not real keys, included for inference */
+  __Types: {
+    stateFn: StateFn;
+  };
+}
+
 function buildCreateHistoryAdapter<StateType extends HistoryStateFn>({
   undoMutably,
   redoMutably,
@@ -215,7 +225,7 @@ function buildCreateHistoryAdapter<StateType extends HistoryStateFn>({
   onCreate,
   getInitialState: getInitialStateCustom = getInitialState,
 }: BuildHistoryAdapterConfig<StateType>) {
-  return function createHistoryAdapter<Data>(
+  function createHistoryAdapter<Data>(
     adapterConfig: HistoryAdapterConfig = {},
   ): HistoryAdapter<Data, ApplyDataType<Data, StateType>> {
     type State = ApplyDataType<Data, StateType>;
@@ -270,7 +280,8 @@ function buildCreateHistoryAdapter<StateType extends HistoryStateFn>({
         });
       },
     };
-  };
+  }
+  return createHistoryAdapter as CreateHistoryAdapter<StateType>;
 }
 
 export const createHistoryAdapter =

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import {
   produceWithPatches,
   produce,
   isDraft,
-  current,
 } from "immer";
 import { ensureCurrent, type NoInfer } from "./utils";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,34 +279,35 @@ interface HistoryStateFn extends BaseHistoryStateFn {
   state: HistoryState<this["data"]>;
 }
 
-export const createHistoryAdapter = buildCreateHistoryAdapter<HistoryStateFn>({
-  applyEntry(state, historyEntry) {
-    const stateBefore = state.present;
-    state.present = historyEntry;
-    return stateBefore;
-  },
-  wrapRecipe:
-    <Data, Args extends Array<any>>(
-      recipe: (
-        draft: Draft<Data>,
-        ...args: Args
-      ) => ValidRecipeReturnType<Data>,
-    ) =>
-    (state: Draft<HistoryState<Data>>, ...args: Args) => {
-      // we need to get the present state before the recipe is applied
-      // and because the recipe might mutate it, we need the non-draft version
-      const before = ensureCurrent(state.present) as Data;
-
-      const result = recipe(state.present as Draft<Data>, ...args);
-      if (result === nothing) {
-        state.present = undefined as never;
-      } else if (typeof result !== "undefined") {
-        state.present = result as never;
-      }
-
-      return before;
+export const createHistoryAdapter =
+  /* @__PURE__ */ buildCreateHistoryAdapter<HistoryStateFn>({
+    applyEntry(state, historyEntry) {
+      const stateBefore = state.present;
+      state.present = historyEntry;
+      return stateBefore;
     },
-});
+    wrapRecipe:
+      <Data, Args extends Array<any>>(
+        recipe: (
+          draft: Draft<Data>,
+          ...args: Args
+        ) => ValidRecipeReturnType<Data>,
+      ) =>
+      (state: Draft<HistoryState<Data>>, ...args: Args) => {
+        // we need to get the present state before the recipe is applied
+        // and because the recipe might mutate it, we need the non-draft version
+        const before = ensureCurrent(state.present) as Data;
+
+        const result = recipe(state.present as Draft<Data>, ...args);
+        if (result === nothing) {
+          state.present = undefined as never;
+        } else if (typeof result !== "undefined") {
+          state.present = result as never;
+        }
+
+        return before;
+      },
+  });
 
 export type PatchState = Record<ApplyOp, Array<Patch>>;
 
@@ -317,7 +318,7 @@ interface PatchHistoryStateFn extends BaseHistoryStateFn {
 }
 
 export const createPatchHistoryAdapter =
-  buildCreateHistoryAdapter<PatchHistoryStateFn>({
+  /* @__PURE__ */ buildCreateHistoryAdapter<PatchHistoryStateFn>({
     onCreate() {
       enablePatches();
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,8 @@ export type BuildHistoryAdapterConfig<StateFn extends BaseHistoryStateFn> = {
   /**
    * Function to apply a history entry to the state.
    * Should return a history entry to be added to the opposite stack (i.e. past or future).
+   *
+   * For example, when undoing, the entry is removed from the past stack, provided to `applyEntry`, and the result is added to the future stack.
    */
   applyEntry: (
     state: StateFn["state"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export interface HistoryAdapterConfig {
   limit?: number;
 }
 
-interface BaseHistoryStateFn {
+export interface BaseHistoryStateFn {
   state: BaseHistoryState<this["data"], unknown>;
   data: unknown;
   config: HistoryAdapterConfig;
@@ -104,7 +104,6 @@ export interface HistoryAdapter<
    * @param state History state shape, with patches
    */
   clearHistory<S extends MaybeDraft<State>>(state: S): S;
-
   /**
    * Wraps a function to automatically update patch history according to changes
    * @param recipe An immer-style recipe, which can mutate the draft or return new state
@@ -117,7 +116,6 @@ export interface HistoryAdapter<
     state: State,
     ...args: Args
   ) => State;
-
   /**
    * Pauses the history, preventing any new patches from being added.
    * @param state History state shape, with patches
@@ -155,7 +153,7 @@ type ApplyEntry<StateFn extends BaseHistoryStateFn> = (
   historyEntry: HistoryEntryType<StateFn["state"]>,
 ) => HistoryEntryType<StateFn["state"]>;
 
-type BuildHistoryAdapterConfig<StateFn extends BaseHistoryStateFn> = {
+export type BuildHistoryAdapterConfig<StateFn extends BaseHistoryStateFn> = {
   /**
    * Function to apply a history entry to the state.
    * Should return a history entry to be added to the opposite stack (i.e. past or future).
@@ -193,7 +191,7 @@ type BuildHistoryAdapterConfig<StateFn extends BaseHistoryStateFn> = {
       getInitialState: GetInitialState<StateFn>;
     });
 
-function buildCreateHistoryAdapter<StateFn extends BaseHistoryStateFn>({
+export function buildCreateHistoryAdapter<StateFn extends BaseHistoryStateFn>({
   applyEntry,
   wrapRecipe,
   onCreate,

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -98,7 +98,8 @@ export interface UndoableMeta {
   undoable?: boolean;
 }
 
-export interface HistoryAdapter<Data> extends Adapter<Data> {
+export interface HistoryAdapter<Data>
+  extends Adapter<Data, MaybeDraftHistoryState<Data>> {
   /**
    * Moves the state back or forward in history by n steps.
    * @param state History state shape, with patches
@@ -138,7 +139,15 @@ export interface HistoryAdapter<Data> extends Adapter<Data> {
     RootState = HistoryState<Data>,
   >(
     reducer: CaseReducer<Data, A>,
-    config?: Omit<UndoableConfig<Data, [action: A], RootState>, "isUndoable">,
+    config?: Omit<
+      UndoableConfig<
+        Data,
+        MaybeDraftHistoryState<Data>,
+        [action: A],
+        RootState
+      >,
+      "isUndoable"
+    >,
   ): <State extends RootState | Draft<RootState>>(
     state: State,
     action: A,

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -9,7 +9,7 @@ import type {
   BaseHistoryState,
   HistoryState,
   UndoableConfig,
-  HistoryAdapterConfig,
+  BaseHistoryAdapterConfig,
   PatchHistoryState,
 } from ".";
 import {
@@ -215,7 +215,7 @@ export function getReduxMethods<
 }
 
 export const createHistoryAdapter = <Data>(
-  config?: HistoryAdapterConfig,
+  config?: BaseHistoryAdapterConfig,
 ): HistoryAdapter<Data> => {
   const adapter = createAdapter<Data>(config);
   return {
@@ -225,7 +225,7 @@ export const createHistoryAdapter = <Data>(
 };
 
 export const createPatchHistoryAdapter = <Data>(
-  config?: HistoryAdapterConfig,
+  config?: BaseHistoryAdapterConfig,
 ): HistoryAdapter<Data, PatchHistoryState<Data>> => {
   const adapter = createPatchAdapter<Data>(config);
   return {

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -178,9 +178,10 @@ export interface HistoryAdapter<
 > extends Omit<Adapter<Data, State>, "jump">,
     ReduxMethods<Data, State> {}
 
-function getReduxMethods<Data, State extends BaseHistoryState<Data, unknown>>(
-  adapter: Adapter<Data, State>,
-): ReduxMethods<Data, State> {
+export function getReduxMethods<
+  Data,
+  State extends BaseHistoryState<Data, unknown>,
+>(adapter: Adapter<Data, State>): ReduxMethods<Data, State> {
   return {
     jump(state, payloadOrAction) {
       return adapter.jump(state, getPayload(payloadOrAction));

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -9,14 +9,13 @@ import type {
   HistoryState,
   UndoableConfig,
   HistoryAdapterConfig,
-  MaybeDraft,
-  NonPatchHistoryState,
+  PatchHistoryState,
 } from ".";
 import {
   createHistoryAdapter as createAdapter,
-  createNoPatchHistoryAdapter as createNoPatchAdapter,
+  createPatchHistoryAdapter as createPatchAdapter,
 } from ".";
-import type { IfMaybeUndefined } from "./utils";
+import type { IfMaybeUndefined, MaybeDraft } from "./utils";
 import type { CreateSelectorFunction, Selector } from "reselect";
 
 export type { HistoryState, HistoryAdapterConfig } from ".";
@@ -221,10 +220,10 @@ export const createHistoryAdapter = <Data>(
   };
 };
 
-export const createNoPatchHistoryAdapter = <Data>(
+export const createPatchHistoryAdapter = <Data>(
   config?: HistoryAdapterConfig,
-): HistoryAdapter<Data, NonPatchHistoryState<Data>> => {
-  const adapter = createNoPatchAdapter<Data>(config);
+): HistoryAdapter<Data, PatchHistoryState<Data>> => {
+  const adapter = createPatchAdapter<Data>(config);
   return {
     ...adapter,
     ...getReduxMethods(adapter),

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -157,7 +157,7 @@ interface ReduxMethods<Data, State extends BaseHistoryState<Data, unknown>> {
   /** Wraps a reducer in logic which automatically updates the state history, and extracts whether an action is undoable from its meta (`action.meta.undoable`) */
   undoableReducer<
     A extends Action & { meta?: UndoableMeta },
-    RootState = HistoryState<Data>,
+    RootState = State,
   >(
     reducer: CaseReducer<Data, A>,
     config?: Omit<

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/export */
 import type { Action, CaseReducer, PayloadAction } from "@reduxjs/toolkit";
 import {
   isFluxStandardAction,
@@ -18,8 +19,7 @@ import {
 import type { IfMaybeUndefined, MaybeDraft } from "./utils";
 import type { CreateSelectorFunction, Selector } from "reselect";
 
-export type { HistoryState, HistoryAdapterConfig } from ".";
-export { getInitialState } from ".";
+export * from ".";
 
 type AnyFunction = (...args: any) => any;
 type AnyCreateSelectorFunction = CreateSelectorFunction<
@@ -119,7 +119,10 @@ function getPayload<P>(payloadOrAction: PayloadAction<P> | P): P {
     : payloadOrAction;
 }
 
-interface ReduxMethods<Data, State extends BaseHistoryState<Data, unknown>> {
+export interface ReduxMethods<
+  Data,
+  State extends BaseHistoryState<Data, unknown>,
+> {
   /**
    * Moves the state back or forward in history by n steps.
    * @param state History state shape, with patches

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -16,7 +16,7 @@ import {
   createHistoryAdapter as createAdapter,
   createPatchHistoryAdapter as createPatchAdapter,
 } from ".";
-import type { IfMaybeUndefined, MaybeDraft, Overwrite } from "./utils";
+import type { IfMaybeUndefined, MaybeDraft } from "./utils";
 import type { CreateSelectorFunction, Selector } from "reselect";
 
 export * from ".";
@@ -175,20 +175,11 @@ export interface ReduxMethods<
   ): HistorySelectors<Data, RootState>;
 }
 
-export type WithReduxMethods<
-  HistoryAdapter extends Adapter<unknown, BaseHistoryState<unknown, unknown>>,
-> = HistoryAdapter extends Adapter<
-  infer Data,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  infer State extends BaseHistoryState<any, unknown>
->
-  ? Overwrite<HistoryAdapter, ReduxMethods<Data, State>>
-  : never;
-
-export type HistoryAdapter<
+export interface HistoryAdapter<
   Data,
   State extends BaseHistoryState<Data, unknown> = HistoryState<Data>,
-> = WithReduxMethods<Adapter<Data, State>>;
+> extends Omit<Adapter<Data, State>, "jump">,
+    ReduxMethods<Data, State> {}
 
 export function getReduxMethods<
   Data,

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -16,7 +16,7 @@ import {
   createHistoryAdapter as createAdapter,
   createPatchHistoryAdapter as createPatchAdapter,
 } from ".";
-import type { IfMaybeUndefined, MaybeDraft } from "./utils";
+import type { IfMaybeUndefined, MaybeDraft, Overwrite } from "./utils";
 import type { CreateSelectorFunction, Selector } from "reselect";
 
 export * from ".";
@@ -175,11 +175,20 @@ export interface ReduxMethods<
   ): HistorySelectors<Data, RootState>;
 }
 
-export interface HistoryAdapter<
+export type WithReduxMethods<
+  HistoryAdapter extends Adapter<unknown, BaseHistoryState<unknown, unknown>>,
+> = HistoryAdapter extends Adapter<
+  infer Data,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  infer State extends BaseHistoryState<any, unknown>
+>
+  ? Overwrite<HistoryAdapter, ReduxMethods<Data, State>>
+  : never;
+
+export type HistoryAdapter<
   Data,
   State extends BaseHistoryState<Data, unknown> = HistoryState<Data>,
-> extends Omit<Adapter<Data, State>, "jump">,
-    ReduxMethods<Data, State> {}
+> = WithReduxMethods<Adapter<Data, State>>;
 
 export function getReduxMethods<
   Data,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,8 +9,6 @@ export type IfMaybeUndefined<T, True, False> = [undefined] extends [T]
 
 export type Compute<T> = { [K in keyof T]: T[K] } & unknown;
 
-export type Overwrite<T, U> = Compute<Omit<T, keyof U> & U>;
-
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,5 +8,3 @@ export type Compute<T> = { [K in keyof T]: T[K] } & unknown;
 
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>;
-
-export type Overwrite<T, U> = Compute<Omit<T, keyof U> & U>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,3 +8,5 @@ export type Compute<T> = { [K in keyof T]: T[K] } & unknown;
 
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>;
+
+export type Overwrite<T, U> = Compute<Omit<T, keyof U> & U>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { current, isDraft } from "immer";
+import type { Draft } from "immer";
+import { current, isDraft, produce } from "immer";
 
 export type NoInfer<T> = [T][T extends any ? 0 : never];
 
@@ -11,5 +12,27 @@ export type Compute<T> = { [K in keyof T]: T[K] } & unknown;
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>;
 
+export type MaybeDraft<T> = T | Draft<T>;
+
+const isDraftTyped = isDraft as <T>(value: MaybeDraft<T>) => value is Draft<T>;
+
 export const ensureCurrent = <T>(value: T) =>
   isDraft(value) ? current(value) : value;
+
+export function makeStateOperator<State, Args extends Array<any> = []>(
+  mutator: (state: Draft<State>, ...args: Args) => void,
+) {
+  return function operator<S extends State | Draft<State>>(
+    state: S,
+    ...args: Args
+  ): S {
+    if (isDraftTyped(state)) {
+      mutator(state as Draft<State>, ...args);
+      return state;
+    } else {
+      return produce(state, (draft) => {
+        mutator(draft as Draft<State>, ...args);
+      });
+    }
+  };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,8 @@ export type IfMaybeUndefined<T, True, False> = [undefined] extends [T]
 
 export type Compute<T> = { [K in keyof T]: T[K] } & unknown;
 
+export type Overwrite<T, U> = Compute<Omit<T, keyof U> & U>;
+
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { current, isDraft } from "immer";
+
 export type NoInfer<T> = [T][T extends any ? 0 : never];
 
 export type IfMaybeUndefined<T, True, False> = [undefined] extends [T]
@@ -8,3 +10,6 @@ export type Compute<T> = { [K in keyof T]: T[K] } & unknown;
 
 export type WithRequiredProp<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>;
+
+export const ensureCurrent = <T>(value: T) =>
+  isDraft(value) ? current(value) : value;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,11 @@
     "moduleResolution": "Bundler",
     "module": "ESNext",
     "noEmit": true,
-    "lib": ["ES2022"]
-  }
+    "lib": [
+      "ES2022"
+    ]
+  },
+  "exclude": [
+    "examples/**/*",
+  ]
 }


### PR DESCRIPTION
Patches seem to end up being bigger than just keeping a copy of state, unless the state is particularly large. Defaulting to keeping a copy, and instead exposing a specific version that uses patches, makes sense.

## Breaking changes

- `createHistoryAdapter` now uses entire copies of state, rather than patches of changes
  - `createPatchHistoryAdapter` available for previous behaviour
  - similarly, `HistoryState` no longer uses patches, whereas `PatchHistoryState` does
- Second argument for `undoable` can no longer be `isUndoable` function - needs to be config object
 
## Other changes

- Build is no longer minified, allowing for better minification in the user's bundler
- API to create custom adapters exported